### PR TITLE
[fix] Call `load_from_checkpoint` as class method for newer lightning versions

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -115,13 +115,9 @@ if __name__ == "__main__":
         model = ort_session
         is_onnx = True
     else:
-        model = EfficientSpeech(preprocess_config=preprocess_config, 
-                                infer_device=args.infer_device,
-                                hifigan_checkpoint=args.hifigan_checkpoint,)
-
-        model = model.load_from_checkpoint(checkpoint,
-                                           infer_device=args.infer_device,
-                                           map_location=torch.device('cpu'))
+        model = EfficientSpeech.load_from_checkpoint(checkpoint,
+                                                     infer_device=args.infer_device,
+                                                     map_location=torch.device('cpu'))
         
 
         model = model.to(args.infer_device)


### PR DESCRIPTION
The following error is thrown in the original code using later versions of Lightning (e.g. 2.2.1):
```
TypeError: The classmethod `EfficientSpeech.load_from_checkpoint` cannot be called on an instance. Please call it on the class type and make sure the return value is used.
```

Fix by changing the code to call `load_from_checkpoint` using class method (see https://github.com/Lightning-AI/pytorch-lightning/issues/18169).